### PR TITLE
Settings being overwritten by defaults

### DIFF
--- a/src/priority-nav.js
+++ b/src/priority-nav.js
@@ -276,8 +276,6 @@
      */
     priorityNav.doesItFit = function (_this) {
 
-        settings = extend(defaults, options || {});
-
         /**
          * Check if it is the first run
          */


### PR DESCRIPTION
Possible copy/paste error whereby the "settings" object is being
overwritten with the "defaults" object when running "doesItFit"
function.  Error can be seen if you set the navDropdownLabel to
something other than "more" and then resize the browser. It resets back
to "more" from the defaults object.