### PR TITLE
Minor changes to polyfill scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ grunt build
 To support Internet Explorer 9 and lower [classList.js](https://github.com/remy/polyfills/blob/master/classList.js/) must be added your page.
 
 ```html
-<!--[if lt IE 9]><script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.0.8/es5-shim.min.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/classlist/2014.01.31/classList.min.js"></script><![endif]-->
 ```
 
 ### IE8 Support

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To support Internet Explorer 9 and lower [classList.js](https://github.com/remy/
 To support Internet Explorer 8, [es5-shim](https://github.com/kriskowal/es5-shim/) and classList.js from above must be added your page.
 
 ```html
-<!--[if lt IE 9]><script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.0.8/es5-shim.min.js"></script><![endif]-->
+<!--[if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/es5-shim/2.0.8/es5-shim.min.js"></script><![endif]-->
 ```
 
 ### Alternatives


### PR DESCRIPTION
I have updated the URL for `classList.js`, as this was pointing to `es5-shim` (possibly copy/pasted from the code block below. A further commit changes the protocol on the link to load `es5-shim` over `https`.
