### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 PriorityNav is a pure javascript plugin that will move your menu items if they don't fit its parent.
 ![Priority Navigation demo](http://gijsroge.github.io/priority-nav.js/priority-nav-demo.gif)
 
-####Take a look at the **[Demo](http://gijsroge.github.io/priority-nav.js/)** site.
+#### Take a look at the **[Demo](http://gijsroge.github.io/priority-nav.js/)** site.
 
 ----------
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
